### PR TITLE
Fix command for initializing orchestration using docker-compose

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -161,7 +161,7 @@ root of a local clone of the source:
     Server = mail.changeme.com
     Sender = Change Me
 
-2. Run ``docker-compose-up``
+2. Run ``docker-compose up``
 
 First-Time Use
 --------------


### PR DESCRIPTION
The README says to run `docker-compose-up`. The command should be `docker-compose up` where `docker-compose` is the application and `up` is the parameter.

See https://docs.docker.com/compose/reference/up/