### PR TITLE
Improve docker files for immutable prod and live dev

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+Dockerfile
+docker-compose.yml

--- a/README.rst
+++ b/README.rst
@@ -161,7 +161,9 @@ root of a local clone of the source:
     Server = mail.changeme.com
     Sender = Change Me
 
-2. Run ``docker-compose up``
+2. Run ``docker-compose up --build`` for a production like deployment running behind ``gunicorn`` in an immutable image
+   so any source code changes require a rebuild. If, however, you want a more dynamic environment for development
+   add in the development config file with ``docker-compose -f docker-compose.yml -f docker-compose.dev.yml up --build`` where source changes occur immediately within the image. Modifying ``requirements.txt`` requires a rebuild of the image however.
 
 First-Time Use
 --------------

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,9 @@
+version: '2'
+
+services:
+  web:
+    volumes:
+      - '.:/usr/src/app'
+    environment:
+      FLASK_ENV: development
+    command: python -m flask run --host 0.0.0.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,18 @@
-version: '3'
+version: '2'
 
 services:
   db:
-    image: postgres
+    image: postgres:alpine
     volumes:
-      - ./sql_init.sh:/docker-entrypoint-initdb.d/init_user_db.sh
-      - ./postgres-data:/var/lib/postgresql/data
+      - './sql_init.sh:/docker-entrypoint-initdb.d/init_user_db.sh:ro'
+      - 'pg_data:/var/lib/postgresql/data'
+
   web:
     build: .
-    command: python -m flask run --host 0.0.0.0
-    volumes:
-      - .:/contextualise
     ports:
       - "5000:5000"
     depends_on:
       - db
+
+volumes:
+  pg_data:


### PR DESCRIPTION
Rewrote the docker related files to produce small, reproducible images
while still allowing for the previous development type of image with a
supplemental docker-compose file. While this is suitable for use on the
docker hub it still takes some effort due to the settings.ini which
should have its values be overridable via environment variable.